### PR TITLE
Move jackson stuff out of WeatherService

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@
 hs_err_pid*
 replay_pid*
 /cache/
+/.idea/
+/target/

--- a/src/main/java/identity/weather/WeatherService.java
+++ b/src/main/java/identity/weather/WeatherService.java
@@ -1,11 +1,9 @@
 package identity.weather;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import util.Fetch;
+import util.ObjectMapperUtil;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -13,13 +11,12 @@ import java.util.List;
 
 public final class WeatherService {
 
-  private static final ObjectReader OBJECT_READER = new ObjectMapper().reader();
+  private static final ObjectReader OBJECT_READER = ObjectMapperUtil.newBasicObjectReader();
 
   public static HourlyData getHourlyData(LatLong latLong, LocalDate startDate, LocalDate endDate)
       throws IOException {
 
-    var uri = new QueryBuilder(latLong, startDate, endDate).toURI();
-    //System.err.println(uri);
+    var uri = new QueryBuilder(latLong).dateRange(startDate, endDate).toURI();
 
     var body = Fetch.cache(uri, Fetch::fetch);
 
@@ -30,11 +27,6 @@ public final class WeatherService {
   public record LatLong(double latitude, double longitude) {}
 
   public record Temperature(float value) {
-    @JsonCreator
-    public Temperature(double value) {
-      this((float) value);
-    }
-
     @Override
     public String toString() {
       return value + " °C";
@@ -57,10 +49,6 @@ public final class WeatherService {
       //super();
     }
 
-    @JsonCreator
-    public Windspeed(double value) {
-      this((float) value);
-    }
 
     @Override
     public String toString() {
@@ -80,11 +68,6 @@ public final class WeatherService {
       //super();
     }
 
-    @JsonCreator
-    public Precipitation(double value) {
-      this((float) value);
-    }
-
     @Override
     public String toString() {
       return value + " mm";
@@ -95,13 +78,11 @@ public final class WeatherService {
     }
   }
 
-  @JsonIgnoreProperties(ignoreUnknown = true)
   public record HourlyData(
       @JsonProperty("temperature_2m") List<Temperature> temperatures,
       @JsonProperty("wind_speed_10m") List<Windspeed> windspeeds,
       @JsonProperty("precipitation") List<Precipitation> precipitations
   ) {}
 
-  @JsonIgnoreProperties(ignoreUnknown = true)
   private record OpenMeteoResponse(HourlyData hourly) {}
 }

--- a/src/main/java/primitive/weather/WeatherService.java
+++ b/src/main/java/primitive/weather/WeatherService.java
@@ -1,6 +1,5 @@
 package primitive.weather;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
@@ -16,8 +15,7 @@ public final class WeatherService {
   public static HourlyData getHourlyData(LatLong latLong, LocalDate startDate, LocalDate endDate)
       throws IOException {
 
-    var uri = new QueryBuilder(latLong, startDate, endDate).toURI();
-    //System.err.println(uri);
+    var uri = new QueryBuilder(latLong).dateRange(startDate, endDate).toURI();
 
     var body = Fetch.cache(uri, Fetch::fetch);
 
@@ -27,13 +25,11 @@ public final class WeatherService {
 
   public record LatLong(double latitude, double longitude) {}
 
-  @JsonIgnoreProperties(ignoreUnknown = true)
   public record HourlyData(
       @JsonProperty("temperature_2m") float[] temperatures,
       @JsonProperty("wind_speed_10m") float[] windspeeds,
       @JsonProperty("precipitation") float[] precipitations
   ) {}
 
-  @JsonIgnoreProperties(ignoreUnknown = true)
   private record OpenMeteoResponse(HourlyData hourly) {}
 }

--- a/src/main/java/util/ObjectMapperUtil.java
+++ b/src/main/java/util/ObjectMapperUtil.java
@@ -1,0 +1,63 @@
+package util;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.cfg.CoercionAction;
+import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.type.LogicalType;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Function;
+
+public final class ObjectMapperUtil {
+
+  public static ObjectReader newBasicObjectReader() {
+    return newBasicMapper().reader();
+  }
+
+  public static ObjectReader newTypeAwareObjectReader() {
+    var module = new SimpleModule();
+    module.addDeserializer(List.class, new TypeAwareListDeserializer(null));
+    var mapper = newBasicMapper();
+    mapper.registerModule(module);
+
+    return mapper.reader();
+  }
+
+  private static ObjectMapper newBasicMapper() {
+    var mapper = new ObjectMapper()
+      .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    mapper.coercionConfigFor(LogicalType.Float)
+      .setCoercion(CoercionInputShape.Float, CoercionAction.TryConvert);
+
+    SimpleModule module = new SimpleModule();
+    // Identity
+    module.addDeserializer(identity.weather.WeatherService.Temperature.class, floatRecordDeserializer(identity.weather.WeatherService.Temperature::new));
+    module.addDeserializer(identity.weather.WeatherService.Windspeed.class, floatRecordDeserializer(identity.weather.WeatherService.Windspeed::new));
+    module.addDeserializer(identity.weather.WeatherService.Precipitation.class, floatRecordDeserializer(identity.weather.WeatherService.Precipitation::new));
+
+    // Value
+    module.addDeserializer(value.weather.WeatherService.Temperature.class, floatRecordDeserializer(value.weather.WeatherService.Temperature::new));
+    module.addDeserializer(value.weather.WeatherService.Windspeed.class, floatRecordDeserializer(value.weather.WeatherService.Windspeed::new));
+    module.addDeserializer(value.weather.WeatherService.Precipitation.class, floatRecordDeserializer(value.weather.WeatherService.Precipitation::new));
+
+    mapper.registerModule(module);
+
+    return mapper;
+  }
+
+  private static <T> JsonDeserializer<T> floatRecordDeserializer(Function<Float, T> constructor) {
+    return new JsonDeserializer<>() {
+      @Override
+      public T deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+        return constructor.apply((float) parser.getDoubleValue());
+      }
+    };
+  }
+}


### PR DESCRIPTION
Simplify the `WeatherService` by moving and configuring Jackson outside.
Will make demo clearer.

Also, changed the `QueryBuilder` calls to be more "builder-like"